### PR TITLE
fix injectionPossible-check for anonymous classes

### DIFF
--- a/service/src/main/java/org/ops4j/pax/wicket/internal/injection/BundleAnalysingComponentInstantiationListener.java
+++ b/service/src/main/java/org/ops4j/pax/wicket/internal/injection/BundleAnalysingComponentInstantiationListener.java
@@ -55,7 +55,7 @@ public class BundleAnalysingComponentInstantiationListener extends AbstractPaxWi
     }
 
     public boolean injectionPossible(Class<?> component) {
-        String name = component.getCanonicalName();
+        String name = component.getName();
         LOGGER.debug("Try to find class {} in bundle {}", name, bundleContext.getBundle().getSymbolicName());
         String searchString = name.replaceAll("\\$\\$.*", "");
         if (bundleResources.matches(".*" + searchString + ".*")) {


### PR DESCRIPTION
canonicalName is null for anonymous classes which could lead to Nullpointer-exceptions during injection:

```
java.lang.NullPointerException
     at org.ops4j.pax.wicket.internal.injection.BundleAnalysingComponentInstantiationListener.injectionPossible(BundleAnalysingComponentInstantiationListener.java:60)
     at org.ops4j.pax.wicket.util.BundleInjectionProviderHelper$BundleInjectionResolver.inject(BundleInjectionProviderHelper.java:144)
     at org.ops4j.pax.wicket.internal.injection.DelegatingComponentInstanciationListener.inject(DelegatingComponentInstanciationListener.java:90)
     at org.ops4j.pax.wicket.internal.injection.ComponentInstantiationListenerFacade.onInstantiation(ComponentInstantiationListenerFacade.java:34)
     at org.apache.wicket.Application.notifyComponentInstantiationListeners(Application.java:1093)
     at org.apache.wicket.Component.<init>(Component.java:923)
     at org.apache.wicket.MarkupContainer.<init>(MarkupContainer.java:113)
     at org.apache.wicket.markup.html.WebMarkupContainer.<init>(WebMarkupContainer.java:49)
     at org.apache.wicket.markup.html.WebMarkupContainerWithAssociatedMarkup.<init>(WebMarkupContainerWithAssociatedMarkup.java:51)
     at org.apache.wicket.markup.html.WebMarkupContainerWithAssociatedMarkup.<init>(WebMarkupContainerWithAssociatedMarkup.java:43)
     at org.apache.wicket.markup.html.panel.Panel.<init>(Panel.java:76)
     at org.openengsb.ui.admin.userService.UserListPanel.<init>(UserListPanel.java:30)
     at org.openengsb.ui.admin.userService.UserListPage$1$1.<init>(UserListPage.java:53)
```
